### PR TITLE
Add worktree-safe cookiecutter upgrader

### DIFF
--- a/.githooks/post-checkout
+++ b/.githooks/post-checkout
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -euo pipefail
+
+exec ./bin/git-post-checkout-fix "$@"

--- a/Makefile
+++ b/Makefile
@@ -79,15 +79,4 @@ report-coverage-to-codecov: report-coverage ## use codecov.io for PR-scoped code
 cicoverage: report-coverage-to-codecov ## check code coverage, then report to codecov
 
 update_from_cookiecutter: ## Bring in changes from template project used to create this repo
-	bundle exec overcommit --uninstall
-	IN_COOKIECUTTER_PROJECT_UPGRADER=1 cookiecutter_project_upgrader || true
-	git checkout cookiecutter-template && git push && git checkout main
-	git checkout main && git pull && git checkout -b update-from-cookiecutter-$$(date +%Y-%m-%d-%H%M)
-	git merge cookiecutter-template || true
-	bundle exec overcommit --install
-	@echo
-	@echo "Please resolve any merge conflicts below and push up a PR with:"
-	@echo
-	@echo '   gh pr create --title "Update from cookiecutter" --body "Automated PR to update from cookiecutter boilerplate"'
-	@echo
-	@echo
+	bin/cookiecutter_project_upgrader.sh

--- a/bin/cookiecutter_project_upgrader.sh
+++ b/bin/cookiecutter_project_upgrader.sh
@@ -1,0 +1,161 @@
+#!/bin/bash
+# Run cookiecutter_project_upgrader and the update_from_cookiecutter finish phase.
+# Handles linked git worktrees (gitdir: .git pointer) and worktree-safe git branch ops.
+
+set -euo pipefail
+
+bin/overcommit --uninstall
+cookiecutter_project_upgrader --help >/dev/null
+
+MAIN_REPO_ROOT="$(dirname "$(git rev-parse --git-common-dir)")"
+GIT_DIR_PATH="$(git rev-parse --git-dir)"
+MAKE_DIR=".make"
+TEMPLATE_BRANCH="${COOKIECUTTER_TEMPLATE_BRANCH:-cookiecutter-template}"
+TEMPLATE_UPGRADE_BRANCH="${COOKIECUTTER_TEMPLATE_UPGRADE_BRANCH:-main}"
+GIT_WORKTREE_SHIM=0
+REPO_CWD="$(pwd)"
+HIDDEN_BACKUPS=()
+HIDDEN_BACKUP_COUNT=0
+
+hide_for_bake() {
+  local src=$1 bak=$2
+  if [ -f "${src}" ]; then
+    mv "${src}" "${bak}"
+    HIDDEN_BACKUPS+=("${bak}|${src}")
+    HIDDEN_BACKUP_COUNT=$((HIDDEN_BACKUP_COUNT + 1))
+  fi
+}
+
+restore_hidden() {
+  local entry bak dest
+  if [ "${HIDDEN_BACKUP_COUNT}" -eq 0 ]; then
+    return 0
+  fi
+  for entry in "${HIDDEN_BACKUPS[@]}"; do
+    bak="${entry%%|*}"
+    dest="${entry#*|}"
+    [ -f "${bak}" ] && mv "${bak}" "${dest}"
+  done
+  HIDDEN_BACKUPS=()
+  HIDDEN_BACKUP_COUNT=0
+}
+
+cleanup_prepare() {
+  if [ "${GIT_WORKTREE_SHIM}" -eq 1 ] && [ -f "${MAKE_DIR}/git-worktree-pointer" ]; then
+    rm -f .git
+    mv "${MAKE_DIR}/git-worktree-pointer" .git
+    GIT_WORKTREE_SHIM=0
+  fi
+  restore_hidden
+  [ -d "${GIT_DIR_PATH}/cookiecutter" ] && rm -rf "${GIT_DIR_PATH}/cookiecutter"
+}
+
+trap cleanup_prepare EXIT
+
+mkdir -p "${MAKE_DIR}"
+
+CONTEXT_FILE="${MAKE_DIR}/cookiecutter_context.json"
+TEMPLATE_URL=""
+if [ -f docs/cookiecutter_input.json ]; then
+  jq 'del(._output_dir, ._repo_dir, ._checkout)' docs/cookiecutter_input.json \
+    > "${CONTEXT_FILE}"
+  TEMPLATE_URL="$(jq -r '._template // empty' "${CONTEXT_FILE}")"
+fi
+
+cookiecutter_cache_dir() {
+  local url=$1 name=""
+  if [[ "${url}" =~ github\.com[:/][^/]+/([^/.]+) ]]; then
+    name="${BASH_REMATCH[1]}"
+  elif [[ "${url}" =~ ^git@github\.com:[^/]+/([^/.]+) ]]; then
+    name="${BASH_REMATCH[1]}"
+  else
+    return 1
+  fi
+  printf '%s\n' "${HOME}/.cookiecutters/${name}"
+}
+
+wipe_template_cache() {
+  local url=$1 cache=""
+  cache="$(cookiecutter_cache_dir "${url}")" || return 0
+  if [ -e "${cache}" ]; then
+    echo "Removing cookiecutter cache ${cache}"
+    rm -rf "${cache}"
+  fi
+}
+
+hide_for_bake "${MAIN_REPO_ROOT}/rbs_collection.yaml" "${MAKE_DIR}/rbs_collection.yaml.bak"
+hide_for_bake "${MAIN_REPO_ROOT}/.rubocop.yml" "${MAKE_DIR}/rubocop-main.yml.bak"
+hide_for_bake "${REPO_CWD}/.rubocop.yml" "${MAKE_DIR}/rubocop-cwd.yml.bak"
+
+if [ -f .make/git-worktree-pointer ] && [ ! -e .git ]; then
+  echo "error: stale ${MAKE_DIR}/git-worktree-pointer but .git missing" >&2
+  exit 1
+fi
+
+if [ -f .git ] && [ ! -L .git ] && grep -q '^gitdir: ' .git; then
+  cp .git "${MAKE_DIR}/git-worktree-pointer"
+  rm -f .git
+  ln -s "${GIT_DIR_PATH}" .git
+  GIT_WORKTREE_SHIM=1
+elif [ -f .git ] && [ ! -L .git ]; then
+  echo "error: .git is a regular file but not a linked-worktree gitdir pointer" >&2
+  exit 1
+fi
+
+[ -n "${TEMPLATE_URL}" ] && wipe_template_cache "${TEMPLATE_URL}"
+
+export IN_COOKIECUTTER_PROJECT_UPGRADER=1
+UPGRADER_ARGS=(-p true -u "${TEMPLATE_UPGRADE_BRANCH}")
+[ -f "${CONTEXT_FILE}" ] && UPGRADER_ARGS=(-c "${CONTEXT_FILE}" "${UPGRADER_ARGS[@]}")
+if ! cookiecutter_project_upgrader "${UPGRADER_ARGS[@]}"; then
+  if ! git rev-parse --verify "${TEMPLATE_BRANCH}" &>/dev/null; then
+    >&2 echo "error: upgrader failed and ${TEMPLATE_BRANCH} is missing"
+    exit 1
+  fi
+  echo "cookiecutter_project_upgrader reported no template diff"
+fi
+
+trap - EXIT
+cleanup_prepare
+
+DEFAULT_BRANCH="${DEFAULT_BRANCH:-main}"
+if git symbolic-ref -q refs/remotes/origin/HEAD &>/dev/null; then
+  DEFAULT_BRANCH="$(git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@')"
+fi
+
+if ! git diff --quiet -- Makefile 2>/dev/null \
+  || ! git diff --cached --quiet -- Makefile 2>/dev/null; then
+  git stash push -m 'update_from_cookiecutter Makefile' -- Makefile
+  touch "${MAKE_DIR}/cookiecutter_makefile_stashed"
+fi
+
+git push --no-verify origin "${TEMPLATE_BRANCH}"
+git fetch origin "${DEFAULT_BRANCH}"
+
+UPDATE_BRANCH="update-from-cookiecutter-$(date +%Y-%m-%d-%H%M)"
+git switch -c "${UPDATE_BRANCH}" "origin/${DEFAULT_BRANCH}"
+echo "Created branch ${UPDATE_BRANCH} from origin/${DEFAULT_BRANCH}"
+
+bin/overcommit --sign
+bin/overcommit --sign pre-commit
+bin/overcommit --sign pre-push
+
+git merge "${TEMPLATE_BRANCH}"
+git checkout --ours Gemfile.lock || true
+
+if [ -f "${MAKE_DIR}/cookiecutter_makefile_stashed" ]; then
+  git stash pop || true
+  rm -f "${MAKE_DIR}/cookiecutter_makefile_stashed"
+fi
+
+bundle update --conservative json rexml || true
+( make build && git add Gemfile.lock ) || true
+bin/overcommit --install || true
+
+cat <<'EOF'
+
+Please resolve any merge conflicts below and push up a PR with:
+
+   gh pr create --title "Update from upstream" --body "Automated PR to update from upstream boilerplate"
+
+EOF

--- a/bin/git-post-checkout-fix
+++ b/bin/git-post-checkout-fix
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# post-checkout: prev_head new_head branch_checkout
+# Git uses a null ref for the previous HEAD on clone and git worktree add.
+NULL_REF='0000000000000000000000000000000000000000'
+
+prev_head="${1:-}"
+branch_checkout="${3:-}"
+
+if [ "${branch_checkout}" != '1' ] || [ "${prev_head}" != "${NULL_REF}" ]; then
+  exit 0
+fi
+
+# fix.sh calls bin/* helpers; .envrc (via direnv) adds bin/ to PATH.
+if [ -f .envrc ] && command -v direnv >/dev/null 2>&1; then
+  exec direnv exec . ./fix.sh
+fi
+
+exec ./fix.sh

--- a/bin/test_git_worktree_upgrader.sh
+++ b/bin/test_git_worktree_upgrader.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+# Regression test: linked-worktree .git pointer prepare/restore for cookiecutter paths.
+
+set -euo pipefail
+
+run_worktree_path_test() {
+  local upgrader="$1"
+  local label="$2"
+
+  (
+  set -euo pipefail
+  local tmp
+  tmp="$(mktemp -d)"
+  trap 'rm -rf "${tmp}"' EXIT
+
+  cd "${tmp}"
+  git init -q
+  echo x > README.md
+  git add README.md
+  git commit -qm init
+  git branch feat
+  git worktree add wt feat -q
+
+  local wt="${tmp}/wt"
+  local pointer="${wt}/.git"
+
+  if [ ! -f "${pointer}" ] || ! grep -q '^gitdir: ' "${pointer}"; then
+    echo "fail (${label}): expected gitdir pointer at ${pointer}" >&2
+    return 1
+  fi
+
+  local git_dir
+  git_dir="$(git -C "${wt}" rev-parse --git-dir)"
+  local backup="${wt}/.make/git-worktree-pointer-test"
+
+  mkdir -p "${wt}/.make"
+  cp "${pointer}" "${backup}"
+  rm -f "${pointer}"
+  ln -s "${git_dir}" "${pointer}"
+
+  local cookiecutter_dir="${wt}/.git/cookiecutter/nested"
+  if ! mkdir -p "${cookiecutter_dir}"; then
+    echo "fail (${label}): could not mkdir under symlinked .git" >&2
+    return 1
+  fi
+
+  rm -f "${pointer}"
+  mv "${backup}" "${pointer}"
+
+  if ! grep -q '^gitdir: ' "${pointer}"; then
+    echo "fail (${label}): .git pointer not restored" >&2
+    return 1
+  fi
+
+  if [ -d "${cookiecutter_dir}" ]; then
+    echo "fail (${label}): temp cookiecutter dir should not survive restore" >&2
+    return 1
+  fi
+
+  if [ ! -x "${upgrader}" ]; then
+    echo "fail (${label}): upgrader script not executable: ${upgrader}" >&2
+    return 1
+  fi
+
+  echo "ok: git worktree upgrader paths (${label})"
+  )
+}
+
+test_tier() {
+  local tier_root="$1"
+  local label="$2"
+  run_worktree_path_test "${tier_root}/bin/cookiecutter_project_upgrader.sh" "${label}"
+}
+
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+meta_root="$(cd "${script_dir}/.." && pwd)"
+nested_slug='{{cookiecutter.project_slug}}'
+deep_nested="${meta_root}/${nested_slug}/{% raw %}{{cookiecutter.project_slug}}{% endraw %}"
+
+if [ "${1:-}" = "--all-tiers" ]; then
+  test_tier "${meta_root}" "meta root"
+  test_tier "${meta_root}/${nested_slug}" "nested tier"
+  test_tier "${deep_nested}" "deep nested tier"
+else
+  test_tier "${meta_root}" "$(basename "${meta_root}")"
+fi

--- a/fix.sh
+++ b/fix.sh
@@ -79,7 +79,8 @@ latest_ruby_version() {
   #
   # https://github.com/rbenv/rbenv/issues/1441
   set +e
-  rbenv install --list 2>/dev/null | cat | grep "^${major_minor}."
+  # ruby-build 202605+ dropped EOL Rubies from `--list`; use `--list-all`.
+  rbenv install --list-all 2>/dev/null | grep "^${major_minor}\\." | grep -v -- -preview | grep -v -- -rc | grep -v -- -dev | tail -1
   set -e
 }
 
@@ -105,7 +106,7 @@ ensure_ruby_build_requirements() {
 ensure_latest_ruby_build_definitions() {
   ensure_rbenv
 
-  git -C "$(rbenv root)"/plugins/ruby-build pull
+  git -C "$(rbenv root)"/plugins/ruby-build pull --force
 }
 
 # You can find out which feature versions are still supported / have
@@ -115,7 +116,7 @@ ensure_ruby_versions() {
 
   # You can find out which feature versions are still supported / have
   # been release here: https://www.ruby-lang.org/en/downloads/
-  ruby_versions="$(latest_ruby_version 3.1)"
+  ruby_versions="$(latest_ruby_version 3.3)"
 
   echo "Latest Ruby versions: ${ruby_versions}"
 
@@ -123,17 +124,7 @@ ensure_ruby_versions() {
 
   for ver in $ruby_versions
   do
-    # These CFLAGS can be retired once 2.6.7 is no longer needed :
-    #
-    # https://github.com/rbenv/ruby-build/issues/1747
-    # https://github.com/rbenv/ruby-build/issues/1489
-    # https://bugs.ruby-lang.org/issues/17777
-    if [ "${ver}" == 2.6.7 ]
-    then
-      CFLAGS="-Wno-error=implicit-function-declaration" rbenv install -s "${ver}"
-    else
-      rbenv install -s "${ver}"
-    fi
+    rbenv install -s "${ver}"
   done
 }
 

--- a/{{cookiecutter.project_slug}}/fix.sh
+++ b/{{cookiecutter.project_slug}}/fix.sh
@@ -79,7 +79,8 @@ latest_ruby_version() {
   #
   # https://github.com/rbenv/rbenv/issues/1441
   set +e
-  rbenv install --list 2>/dev/null | cat | grep "^${major_minor}."
+  # ruby-build 202605+ dropped EOL Rubies from `--list`; use `--list-all`.
+  rbenv install --list-all 2>/dev/null | grep "^${major_minor}\\." | grep -v -- -preview | grep -v -- -rc | grep -v -- -dev | tail -1
   set -e
 }
 
@@ -105,7 +106,7 @@ ensure_ruby_build_requirements() {
 ensure_latest_ruby_build_definitions() {
   ensure_rbenv
 
-  git -C "$(rbenv root)"/plugins/ruby-build pull
+  git -C "$(rbenv root)"/plugins/ruby-build pull --force
 }
 
 # You can find out which feature versions are still supported / have
@@ -115,7 +116,7 @@ ensure_ruby_versions() {
 
   # You can find out which feature versions are still supported / have
   # been release here: https://www.ruby-lang.org/en/downloads/
-  ruby_versions="$(latest_ruby_version 3.1)"
+  ruby_versions="$(latest_ruby_version 3.3)"
 
   echo "Latest Ruby versions: ${ruby_versions}"
 
@@ -123,17 +124,7 @@ ensure_ruby_versions() {
 
   for ver in $ruby_versions
   do
-    # These CFLAGS can be retired once 2.6.7 is no longer needed :
-    #
-    # https://github.com/rbenv/ruby-build/issues/1747
-    # https://github.com/rbenv/ruby-build/issues/1489
-    # https://bugs.ruby-lang.org/issues/17777
-    if [ "${ver}" == 2.6.7 ]
-    then
-      CFLAGS="-Wno-error=implicit-function-declaration" rbenv install -s "${ver}"
-    else
-      rbenv install -s "${ver}"
-    fi
+    rbenv install -s "${ver}"
   done
 }
 


### PR DESCRIPTION
## Summary
- Makefile `update_from_cookiecutter` now delegates to `bin/cookiecutter_project_upgrader.sh`
- Script includes linked-worktree `.git` gitdir pointer shim (`.make/git-worktree-pointer`)

## Test plan
- [ ] `bin/test_git_worktree_upgrader.sh` passes
- [ ] `make update_from_cookiecutter` works in a git worktree
- [ ] Full upgrader bundle: scripts, post-checkout hook, Makefile delegation