### PR TITLE
Add nested bake upgrader bundle

### DIFF
--- a/{{cookiecutter.project_slug}}/.githooks/post-checkout
+++ b/{{cookiecutter.project_slug}}/.githooks/post-checkout
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -euo pipefail
+
+exec ./bin/git-post-checkout-fix "$@"

--- a/{{cookiecutter.project_slug}}/Makefile
+++ b/{{cookiecutter.project_slug}}/Makefile
@@ -69,15 +69,4 @@ report-coverage-to-codecov: report-coverage ## use codecov.io for PR-scoped code
 cicoverage: report-coverage-to-codecov ## check code coverage, then report to codecov
 
 update_from_cookiecutter: ## Bring in changes from template project used to create this repo
-	bundle exec overcommit --uninstall
-	IN_COOKIECUTTER_PROJECT_UPGRADER=1 cookiecutter_project_upgrader || true
-	git checkout cookiecutter-template && git push && git checkout main
-	git checkout main && git pull && git checkout -b update-from-cookiecutter-$$(date +%Y-%m-%d-%H%M)
-	git merge cookiecutter-template || true
-	bundle exec overcommit --install
-	@echo
-	@echo "Please resolve any merge conflicts below and push up a PR with:"
-	@echo
-	@echo '   gh pr create --title "Update from cookiecutter" --body "Automated PR to update from cookiecutter boilerplate"'
-	@echo
-	@echo
+	bin/cookiecutter_project_upgrader.sh

--- a/{{cookiecutter.project_slug}}/bin/cookiecutter_project_upgrader.sh
+++ b/{{cookiecutter.project_slug}}/bin/cookiecutter_project_upgrader.sh
@@ -1,0 +1,137 @@
+#!/bin/bash
+# Run cookiecutter_project_upgrader and the update_from_cookiecutter finish phase.
+# Handles linked git worktrees (gitdir: .git pointer) and worktree-safe git branch ops.
+
+set -euo pipefail
+
+bin/overcommit --uninstall
+cookiecutter_project_upgrader --help >/dev/null
+
+MAIN_REPO_ROOT="$(dirname "$(git rev-parse --git-common-dir)")"
+GIT_DIR_PATH="$(git rev-parse --git-dir)"
+MAKE_DIR=".make"
+RBS_HIDDEN=0
+RUBOCOP_MAIN_HIDDEN=0
+RUBOCOP_CWD_HIDDEN=0
+GIT_WORKTREE_SHIM=0
+REPO_CWD="$(pwd)"
+
+cleanup_prepare() {
+  if [ "${GIT_WORKTREE_SHIM}" -eq 1 ] && [ -f "${MAKE_DIR}/git-worktree-pointer" ]; then
+    rm -f .git
+    mv "${MAKE_DIR}/git-worktree-pointer" .git
+    GIT_WORKTREE_SHIM=0
+  fi
+  if [ "${RBS_HIDDEN}" -eq 1 ] && [ -f "${MAKE_DIR}/rbs_collection.yaml.bak" ]; then
+    mv "${MAKE_DIR}/rbs_collection.yaml.bak" "${MAIN_REPO_ROOT}/rbs_collection.yaml"
+    rm -f "${MAKE_DIR}/rbs_collection_yaml_hidden"
+    RBS_HIDDEN=0
+  fi
+  if [ "${RUBOCOP_MAIN_HIDDEN}" -eq 1 ] && [ -f "${MAKE_DIR}/rubocop-main.yml.bak" ]; then
+    mv "${MAKE_DIR}/rubocop-main.yml.bak" "${MAIN_REPO_ROOT}/.rubocop.yml"
+    rm -f "${MAKE_DIR}/rubocop_main_hidden"
+    RUBOCOP_MAIN_HIDDEN=0
+  fi
+  if [ "${RUBOCOP_CWD_HIDDEN}" -eq 1 ] && [ -f "${MAKE_DIR}/rubocop-cwd.yml.bak" ]; then
+    mv "${MAKE_DIR}/rubocop-cwd.yml.bak" "${REPO_CWD}/.rubocop.yml"
+    rm -f "${MAKE_DIR}/rubocop_cwd_hidden"
+    RUBOCOP_CWD_HIDDEN=0
+  fi
+  if [ -d "${GIT_DIR_PATH}/cookiecutter" ]; then
+    rm -rf "${GIT_DIR_PATH}/cookiecutter"
+  fi
+}
+
+trap cleanup_prepare EXIT
+
+mkdir -p "${MAKE_DIR}"
+
+if [ -f docs/cookiecutter_input.json ]; then
+  jq 'del(._output_dir, ._repo_dir, ._checkout)' docs/cookiecutter_input.json \
+    > "${MAKE_DIR}/cookiecutter_context.json"
+fi
+
+if [ -f "${MAIN_REPO_ROOT}/rbs_collection.yaml" ]; then
+  mv "${MAIN_REPO_ROOT}/rbs_collection.yaml" "${MAKE_DIR}/rbs_collection.yaml.bak"
+  touch "${MAKE_DIR}/rbs_collection_yaml_hidden"
+  RBS_HIDDEN=1
+fi
+if [ -f "${MAIN_REPO_ROOT}/.rubocop.yml" ]; then
+  mv "${MAIN_REPO_ROOT}/.rubocop.yml" "${MAKE_DIR}/rubocop-main.yml.bak"
+  touch "${MAKE_DIR}/rubocop_main_hidden"
+  RUBOCOP_MAIN_HIDDEN=1
+fi
+# Nested tiers may have their own .rubocop.yml; hide it so RuboCop does not inherit
+# mismatched config while cookiecutter_project_upgrader runs under .git/cookiecutter/
+if [ -f "${REPO_CWD}/.rubocop.yml" ]; then
+  mv "${REPO_CWD}/.rubocop.yml" "${MAKE_DIR}/rubocop-cwd.yml.bak"
+  touch "${MAKE_DIR}/rubocop_cwd_hidden"
+  RUBOCOP_CWD_HIDDEN=1
+fi
+
+if [ -f .make/git-worktree-pointer ] && [ ! -f .git ] && [ ! -L .git ]; then
+  echo "error: stale ${MAKE_DIR}/git-worktree-pointer but .git is missing; restore manually" >&2
+  exit 1
+fi
+
+if [ -f .git ] && [ ! -L .git ] && grep -q '^gitdir: ' .git; then
+  cp .git "${MAKE_DIR}/git-worktree-pointer"
+  rm -f .git
+  ln -s "${GIT_DIR_PATH}" .git
+  GIT_WORKTREE_SHIM=1
+elif [ -f .git ] && [ ! -L .git ]; then
+  echo "error: .git is a regular file but not a linked-worktree gitdir pointer" >&2
+  exit 1
+fi
+
+export IN_COOKIECUTTER_PROJECT_UPGRADER=1
+if [ -f "${MAKE_DIR}/cookiecutter_context.json" ]; then
+  cookiecutter_project_upgrader -c "${MAKE_DIR}/cookiecutter_context.json" -p true
+else
+  cookiecutter_project_upgrader
+fi
+
+trap - EXIT
+cleanup_prepare
+
+# Finish phase (worktree-safe: no checkout of branches locked in other worktrees)
+DEFAULT_BRANCH="${DEFAULT_BRANCH:-main}"
+if git symbolic-ref -q "refs/remotes/origin/HEAD" >/dev/null 2>&1; then
+  DEFAULT_BRANCH="$(git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@')"
+fi
+
+if ! git diff --quiet -- Makefile 2>/dev/null || ! git diff --cached --quiet -- Makefile 2>/dev/null; then
+  git stash push -m 'update_from_cookiecutter Makefile' -- Makefile
+  touch "${MAKE_DIR}/cookiecutter_makefile_stashed"
+fi
+
+git push --no-verify origin cookiecutter-template || true
+
+git fetch "origin" "${DEFAULT_BRANCH}"
+UPDATE_BRANCH="update-from-cookiecutter-$(date +%Y-%m-%d-%H%M)"
+git switch -c "${UPDATE_BRANCH}" "origin/${DEFAULT_BRANCH}"
+echo "Created branch ${UPDATE_BRANCH} from origin/${DEFAULT_BRANCH}"
+
+bin/overcommit --sign
+bin/overcommit --sign pre-commit
+bin/overcommit --sign pre-push
+
+git merge cookiecutter-template || true
+git checkout --ours Gemfile.lock || true
+
+if [ -f "${MAKE_DIR}/cookiecutter_makefile_stashed" ]; then
+  git stash pop || true
+  rm -f "${MAKE_DIR}/cookiecutter_makefile_stashed"
+fi
+
+git checkout --theirs sorbet/rbi/gems || true
+bundle update --conservative json nokogiri rack rexml yard brakeman || true
+( make build && git add Gemfile.lock ) || true
+bin/spoom srb bump || true
+bin/overcommit --install || true
+
+echo
+echo "Please resolve any merge conflicts below and push up a PR with:"
+echo
+echo '   gh pr create --title "Update from cookiecutter" --body "Automated PR to update from cookiecutter boilerplate"'
+echo

--- a/{{cookiecutter.project_slug}}/bin/git-post-checkout-fix
+++ b/{{cookiecutter.project_slug}}/bin/git-post-checkout-fix
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# post-checkout: prev_head new_head branch_checkout
+# Git uses a null ref for the previous HEAD on clone and git worktree add.
+NULL_REF='0000000000000000000000000000000000000000'
+
+prev_head="${1:-}"
+branch_checkout="${3:-}"
+
+if [ "${branch_checkout}" != '1' ] || [ "${prev_head}" != "${NULL_REF}" ]; then
+  exit 0
+fi
+
+# fix.sh calls bin/* helpers; .envrc (via direnv) adds bin/ to PATH.
+if [ -f .envrc ] && command -v direnv >/dev/null 2>&1; then
+  exec direnv exec . ./fix.sh
+fi
+
+exec ./fix.sh

--- a/{{cookiecutter.project_slug}}/bin/test_git_worktree_upgrader.sh
+++ b/{{cookiecutter.project_slug}}/bin/test_git_worktree_upgrader.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+# Regression test: linked-worktree .git pointer prepare/restore for cookiecutter paths.
+
+set -euo pipefail
+
+run_worktree_path_test() {
+  local upgrader="$1"
+  local label="$2"
+
+  (
+  set -euo pipefail
+  local tmp
+  tmp="$(mktemp -d)"
+  trap 'rm -rf "${tmp}"' EXIT
+
+  cd "${tmp}"
+  git init -q
+  echo x > README.md
+  git add README.md
+  git commit -qm init
+  git branch feat
+  git worktree add wt feat -q
+
+  local wt="${tmp}/wt"
+  local pointer="${wt}/.git"
+
+  if [ ! -f "${pointer}" ] || ! grep -q '^gitdir: ' "${pointer}"; then
+    echo "fail (${label}): expected gitdir pointer at ${pointer}" >&2
+    return 1
+  fi
+
+  local git_dir
+  git_dir="$(git -C "${wt}" rev-parse --git-dir)"
+  local backup="${wt}/.make/git-worktree-pointer-test"
+
+  mkdir -p "${wt}/.make"
+  cp "${pointer}" "${backup}"
+  rm -f "${pointer}"
+  ln -s "${git_dir}" "${pointer}"
+
+  local cookiecutter_dir="${wt}/.git/cookiecutter/nested"
+  if ! mkdir -p "${cookiecutter_dir}"; then
+    echo "fail (${label}): could not mkdir under symlinked .git" >&2
+    return 1
+  fi
+
+  rm -f "${pointer}"
+  mv "${backup}" "${pointer}"
+
+  if ! grep -q '^gitdir: ' "${pointer}"; then
+    echo "fail (${label}): .git pointer not restored" >&2
+    return 1
+  fi
+
+  if [ -d "${cookiecutter_dir}" ]; then
+    echo "fail (${label}): temp cookiecutter dir should not survive restore" >&2
+    return 1
+  fi
+
+  if [ ! -x "${upgrader}" ]; then
+    echo "fail (${label}): upgrader script not executable: ${upgrader}" >&2
+    return 1
+  fi
+
+  echo "ok: git worktree upgrader paths (${label})"
+  )
+}
+
+test_tier() {
+  local tier_root="$1"
+  local label="$2"
+  run_worktree_path_test "${tier_root}/bin/cookiecutter_project_upgrader.sh" "${label}"
+}
+
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+meta_root="$(cd "${script_dir}/.." && pwd)"
+nested_slug='cookiecutter-ruby'
+deep_nested="${meta_root}/${nested_slug}/checkoff"
+
+if [ "${1:-}" = "--all-tiers" ]; then
+  test_tier "${meta_root}" "meta root"
+  test_tier "${meta_root}/${nested_slug}" "nested tier"
+  test_tier "${deep_nested}" "deep nested tier"
+else
+  test_tier "${meta_root}" "$(basename "${meta_root}")"
+fi


### PR DESCRIPTION
## Summary
- Add `{{cookiecutter.project_slug}}/bin/cookiecutter_project_upgrader.sh` (+ test, post-checkout hook) for baked Terraform projects
- Nested `Makefile` now delegates to `bin/cookiecutter_project_upgrader.sh` instead of calling the Python `cookiecutter_project_upgrader` CLI directly

Root template repo already had the meta-tier upgrader; this fixes the **nested bake layer** that ships into repos like apiology-tf.

## Test plan
- [ ] CI green
- [ ] `bin/test_git_worktree_upgrader.sh` passes on branch

Made with [Cursor](https://cursor.com)