### PR TITLE
Update from upstream

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,8 +54,8 @@ commands:
       - restore_cache:
           name: Restore pyenv cache
           keys:
-            - pyenv-v2-{{ checksum "requirements_dev.txt" }}-
-            - pyenv-v2-
+            - pyenv-v3-{{ checksum "requirements_dev.txt" }}-
+            - pyenv-v3-
             - pyenv-
       - run:
           name: Initialize packages
@@ -74,7 +74,7 @@ commands:
           path: /tmp/fix_sh_timing.log
       - save_cache:
           name: 'Save pyenv cache'
-          key: pyenv-v2-{{ checksum "requirements_dev.txt" }}-{{ checksum ".python-version" }} # yamllint disable-line rule:line-length
+          key: pyenv-v3-{{ checksum "requirements_dev.txt" }}-{{ checksum ".python-version" }} # yamllint disable-line rule:line-length
           paths:
             - "requirements_dev.txt.installed"
             - "/home/circleci/.cache/pip/wheels"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,9 +54,8 @@ commands:
       - restore_cache:
           name: Restore pyenv cache
           keys:
-            - pyenv-v3-{{ checksum "requirements_dev.txt" }}-
-            - pyenv-v3-
-            - pyenv-
+            - pyenv-cache-v1-{{ checksum "requirements_dev.txt" }}-
+            - pyenv-cache-v1-
       - run:
           name: Initialize packages
           no_output_timeout: 30m
@@ -74,7 +73,7 @@ commands:
           path: /tmp/fix_sh_timing.log
       - save_cache:
           name: 'Save pyenv cache'
-          key: pyenv-v3-{{ checksum "requirements_dev.txt" }}-{{ checksum ".python-version" }} # yamllint disable-line rule:line-length
+          key: pyenv-cache-v1-{{ checksum "requirements_dev.txt" }}-{{ checksum ".python-version" }} # yamllint disable-line rule:line-length
           paths:
             - "requirements_dev.txt.installed"
             - "/home/circleci/.cache/pip/wheels"

--- a/.cursor/rules/worktree-env-local-probe.mdc
+++ b/.cursor/rules/worktree-env-local-probe.mdc
@@ -1,7 +1,7 @@
 ---
 description: >-
-  Cursor worktree bootstrap failed or env.local/op run debugging — read
-  file-based probe logs before inferring from missing direnv stderr
+  Worktree bootstrap failed, script/ ops blocked, or op/env.local confusion —
+  read probe + git-sync logs and classify before blaming 1Password
 alwaysApply: false
 globs:
   - .envrc
@@ -13,11 +13,15 @@ globs:
 
 `ls`/`cat` redirected to stderr in `.envrc` do **not** appear in worktree-fix bootstrap logs. Use file probes instead.
 
-## Before diagnosing bootstrap
+## Before diagnosing bootstrap or running `script/` ops
 
-1. Read the pointer: `.env-local-probe-path` (one line: absolute log path).
-2. Read the log tail: `~/.cache/env-local-probe/<worktree-basename>.log` (e.g. `kaa0.log`).
-3. If missing or stale, run from repo root: `./bin/probe_env_local` (no direnv required).
+Read **all three** (Grep/Read only while bootstrap is broken):
+
+1. Worktree-fix log — `~/.cache/cursor-apiology-bootstrap/worktree-fix/` (grep worktree path).
+2. Git-sync log — `~/.cursor/hooks/logs/git-sync-hooks.log` (same path; compare timestamps to worktree-fix).
+3. Probe log — `.env-local-probe-path` or `~/.cache/env-local-probe/<worktree-basename>.log`.
+
+If probe log missing for this worktree, run `./bin/probe_env_local` from repo root (no direnv required) or check git-sync vs worktree-fix timestamps — see stale-HEAD row in `apiology-direnv-bootstrap.mdc`.
 
 ## Interpret `which_branch`
 
@@ -28,4 +32,15 @@ globs:
 
 Also check: `-L`/`-r`, `cat exit=` (124 = FIFO with no writer / Environment not mounted), `op_run_fallback` section.
 
+Compare probe block timestamp to `~/.cursor/hooks/logs/git-sync-hooks.log` and worktree-fix log for the same root.
+
 Every `.envrc` eval appends a block (source=`envrc`). Bootstrap retries produce multiple timestamped blocks — compare hook time to latest block.
+
+## Contradiction patterns (classify, then act)
+
+| Pattern | Meaning |
+|---------|---------|
+| Hook log: `worktree-envlocal verified env.local` + fix log: 1Password/`op run` error + **no** probe run at bootstrap time (run `./bin/probe_env_local` to confirm `-L=yes`) | Stale checkout: `./fix.sh` ran before `git sync` merged `origin/main`. Retry bootstrap after sync; do not assume `.envrc` on disk differs from `git show HEAD:.envrc`. |
+| Probe `-L=yes` + fix log `op run` at same timestamp | Same stale-HEAD race or pre-`-L` `.envrc` at old commit. |
+| Probe `which_branch=env.local`, `cat exit=0` | `.envrc` took env.local path; if bootstrap still failed, debug `./fix.sh` output — not `op`. |
+| `git-sync … sync ok (merged …)` one second **after** `worktree-fix start` | Confirms race; hooks now re-sync inline — retry `./fix.sh`. |

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,7 +5,7 @@ GEM
       concurrent-ruby
     childprocess (5.1.0)
       logger (~> 1.5)
-    concurrent-ruby (1.3.7)
+    concurrent-ruby (1.3.8)
     iniparse (1.5.0)
     kramdown (2.5.2)
       rexml (>= 3.4.4)
@@ -43,10 +43,10 @@ DEPENDENCIES
   punchlist (>= 1.3.1)
 
 CHECKSUMS
-  bundler (4.0.15) sha256=a4ceb882fe94a0e0ac63cd0813932bbfd631a14e5ac0b7975189b19a4d28d9e7
+  bundler (4.0.16) sha256=d6ca5dd440c24f9abce9844cf44cc8e18c6a553de65a47efb4544137af92c47d
   chef-utils (19.3.15) sha256=1c537a9c85b55b6d897de8e8af6b66b017a6dfae2b5e7b25e0bf320637e0b86a
   childprocess (5.1.0) sha256=9a8d484be2fd4096a0e90a0cd3e449a05bc3aa33f8ac9e4d6dcef6ac1455b6ec
-  concurrent-ruby (1.3.7) sha256=4412caec3a5ea2e5fdc52076724c071a81f2c0593d83b2ac8cbb8ca63b3151b0
+  concurrent-ruby (1.3.8) sha256=b2f1be836e968ccc78ccfce277ea79c72a88633f22306782c16ff23fb415d1e1
   iniparse (1.5.0) sha256=36a165e98d8a250b7631c4a7f9afba32af78f089970cd6446a39771189c761f1
   kramdown (2.5.2) sha256=1ba542204c66b6f9111ff00dcc26075b95b220b07f2905d8261740c82f7f02fa
   kramdown-parser-gfm (1.1.0) sha256=fb39745516427d2988543bf01fc4cf0ab1149476382393e0e9c48592f6581729
@@ -62,4 +62,4 @@ CHECKSUMS
   tomlrb (2.0.4) sha256=262f77947ac3ac9b3366a0a5940ecd238300c553e2e14f22009e2afcd2181b99
 
 BUNDLED WITH
-  4.0.15
+  4.0.16

--- a/bin/git-post-checkout-fix
+++ b/bin/git-post-checkout-fix
@@ -13,8 +13,20 @@ if [ "${branch_checkout}" != '1' ] || [ "${prev_head}" != "${NULL_REF}" ]; then
   exit 0
 fi
 
-# fix.sh calls bin/* helpers; .envrc (via direnv) adds bin/ to PATH.
-if [ -f .envrc ] && command -v direnv >/dev/null 2>&1; then
+# Git hooks often have a minimal PATH; include common direnv locations.
+export PATH="/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:${HOME}/.rbenv/bin:${HOME}/.local/bin:${PATH}"
+
+# fix.sh calls bin/* helpers; .envrc (via direnv) puts bin/ on PATH.
+# Never run bare ./fix.sh when .envrc exists — that skips PATH_add bin.
+if [ -f .envrc ]; then
+  if ! command -v direnv >/dev/null 2>&1; then
+    echo "git-post-checkout-fix: direnv not found; cannot bootstrap with .envrc" >&2
+    exit 1
+  fi
+  if ! direnv allow .; then
+    echo "git-post-checkout-fix: direnv allow failed" >&2
+    exit 1
+  fi
   exec direnv exec . ./fix.sh
 fi
 

--- a/docs/cookiecutter_input.json
+++ b/docs/cookiecutter_input.json
@@ -1,6 +1,6 @@
 {
     "_checkout": "main",
-    "_output_dir": "/Users/broz/.cursor/worktrees/cookiecutter-terraform/cascade-cookiecutter-terraform-1783739815896/.git/cookiecutter",
+    "_output_dir": "/Users/broz/.cursor/worktrees/cookiecutter-terraform/cascade-cookiecutter-terraform-1784994874648/.git/cookiecutter",
     "_repo_dir": "/Users/broz/.cookiecutters/cookiecutter-cookiecutter",
     "_template": "https://github.com/apiology/cookiecutter-cookiecutter",
     "email": "vince@broz.cc",

--- a/fix.sh
+++ b/fix.sh
@@ -2,6 +2,10 @@
 
 set -o pipefail
 
+# Some tools need UTF-8; Cursor worktree hooks may run with LANG=C (US-ASCII).
+export LANG="${LANG:-en_US.UTF-8}"
+export LC_ALL="${LC_ALL:-en_US.UTF-8}"
+
 if [ -n "${FIX_SH_TIMING_LOG+x}" ]; then
     rm -f "${FIX_SH_TIMING_LOG}"
     if ! type gdate >/dev/null 2>&1; then sudo ln -sf /bin/date /bin/gdate; fi

--- a/fix.sh
+++ b/fix.sh
@@ -426,6 +426,12 @@ ensure_pip_and_wheel() {
 }
 
 ensure_python_requirements() {
+  # Stale CI pyenv caches can restore requirements_dev.txt.installed while the
+  # active virtualenv lacks packages (e.g. after python_versions / venv rename).
+  if ! type mypy >/dev/null 2>&1
+  then
+    rm -f requirements_dev.txt.installed
+  fi
   make pip_install
 }
 

--- a/fix.sh
+++ b/fix.sh
@@ -428,7 +428,8 @@ ensure_pip_and_wheel() {
 ensure_python_requirements() {
   # Stale CI pyenv caches can restore requirements_dev.txt.installed while the
   # active virtualenv lacks packages (e.g. after python_versions / venv rename).
-  if ! type mypy >/dev/null 2>&1
+  # Use import, not `type mypy` — pyenv shims exist for other versions.
+  if ! python -c 'import mypy' >/dev/null 2>&1
   then
     rm -f requirements_dev.txt.installed
   fi

--- a/tests/test_bake_project.py
+++ b/tests/test_bake_project.py
@@ -38,6 +38,57 @@ def suppressed_github_and_circleci_creation():
         del os.environ['SKIP_EXTERNAL']
 
 
+PARENT_HOOK_ENV_VARS = (
+    'GIT_DIR',
+    'GIT_WORK_TREE',
+    'GIT_INDEX_FILE',
+    'BUNDLE_GEMFILE',
+    'BUNDLE_PATH',
+    'BUNDLE_BIN',
+    'BUNDLE_WITHOUT',
+    'BUNDLE_DEPLOYMENT',
+    'BUNDLE_APP_CONFIG',
+    'RUBYOPT',
+)
+
+
+def _parent_hook_env_var(var):
+    return any((
+        var in PARENT_HOOK_ENV_VARS,
+        var.startswith('BUNDLER_ORIG_'),
+        var.startswith('BUNDLE_'),
+        var.startswith('BUNDLER_'),
+        var in ('GEM_HOME', 'GEM_PATH'),
+    ))
+
+
+def _env_without_git_push_vars():
+    """Drop git push/pre-push env so baked-project make targets use local .git."""
+    env = os.environ.copy()
+    for var in list(env):
+        if _parent_hook_env_var(var):
+            env.pop(var, None)
+    if 'PATH' in env:
+        env['PATH'] = os.pathsep.join(
+            part for part in env['PATH'].split(os.pathsep)
+            if part and '/bundle/ruby/' not in part
+        )
+    return env
+
+
+@contextmanager
+def without_parent_hook_env():
+    """Clear git-hook env so cookiecutter post_gen git ops use a fresh repo."""
+    saved = {}
+    for var in list(os.environ):
+        if _parent_hook_env_var(var):
+            saved[var] = os.environ.pop(var)
+    try:
+        yield
+    finally:
+        os.environ.update(saved)
+
+
 def errmsg(exception):
     """Format a cookiecutter or Jinja exception for assertion messages."""
     if isinstance(exception, jinja2.exceptions.TemplateSyntaxError):
@@ -53,7 +104,7 @@ def bake_in_temp_dir(cookies, *args, **kwargs):
     :param args: Positional arguments passed to cookies.bake.
     :param kwargs: Keyword arguments passed to cookies.bake.
     """
-    with suppressed_github_and_circleci_creation():
+    with suppressed_github_and_circleci_creation(), without_parent_hook_env():
         result = cookies.bake(*args, **kwargs)
         assert result is not None, result
         assert result.exception is None, errmsg(result.exception)
@@ -73,7 +124,10 @@ def run_inside_dir(command, dirpath):
     :param dirpath: Working directory for the command.
     """
     with inside_dir(dirpath):
-        return subprocess.check_call(shlex.split(command))
+        return subprocess.check_call(
+            shlex.split(command),
+            env=_env_without_git_push_vars(),
+        )
 
 
 def check_output_inside_dir(command, dirpath):
@@ -83,7 +137,10 @@ def check_output_inside_dir(command, dirpath):
     :param dirpath: Working directory for the command.
     """
     with inside_dir(dirpath):
-        return subprocess.check_output(shlex.split(command))
+        return subprocess.check_output(
+            shlex.split(command),
+            env=_env_without_git_push_vars(),
+        )
 
 
 def project_info(result):

--- a/{{cookiecutter.project_slug}}/.circleci/config.yml
+++ b/{{cookiecutter.project_slug}}/.circleci/config.yml
@@ -54,9 +54,8 @@ commands:
       - restore_cache:
           name: Restore pyenv cache
           keys:
-            - pyenv-v3-{% raw %}{{ checksum "requirements_dev.txt" }}{% endraw %}-
-            - pyenv-v3-
-            - pyenv-
+            - pyenv-cache-v1-{% raw %}{{ checksum "requirements_dev.txt" }}{% endraw %}-
+            - pyenv-cache-v1-
       - run:
           name: Initialize packages
           no_output_timeout: 30m
@@ -74,7 +73,7 @@ commands:
           path: /tmp/fix_sh_timing.log
       - save_cache:
           name: 'Save pyenv cache'
-          key: pyenv-v3-{% raw %}{{ checksum "requirements_dev.txt" }}{% endraw %}-{% raw %}{{ checksum ".python-version" }}{% endraw %}
+          key: pyenv-cache-v1-{% raw %}{{ checksum "requirements_dev.txt" }}{% endraw %}-{% raw %}{{ checksum ".python-version" }}{% endraw %}
           paths:
             - "requirements_dev.txt.installed"
             - "/home/circleci/.cache/pip/wheels"

--- a/{{cookiecutter.project_slug}}/.circleci/config.yml
+++ b/{{cookiecutter.project_slug}}/.circleci/config.yml
@@ -54,8 +54,8 @@ commands:
       - restore_cache:
           name: Restore pyenv cache
           keys:
-            - pyenv-v2-{% raw %}{{ checksum "requirements_dev.txt" }}{% endraw %}-
-            - pyenv-v2-
+            - pyenv-v3-{% raw %}{{ checksum "requirements_dev.txt" }}{% endraw %}-
+            - pyenv-v3-
             - pyenv-
       - run:
           name: Initialize packages
@@ -74,7 +74,7 @@ commands:
           path: /tmp/fix_sh_timing.log
       - save_cache:
           name: 'Save pyenv cache'
-          key: pyenv-v2-{% raw %}{{ checksum "requirements_dev.txt" }}{% endraw %}-{% raw %}{{ checksum ".python-version" }}{% endraw %}
+          key: pyenv-v3-{% raw %}{{ checksum "requirements_dev.txt" }}{% endraw %}-{% raw %}{{ checksum ".python-version" }}{% endraw %}
           paths:
             - "requirements_dev.txt.installed"
             - "/home/circleci/.cache/pip/wheels"

--- a/{{cookiecutter.project_slug}}/.cursor/rules/worktree-env-local-probe.mdc
+++ b/{{cookiecutter.project_slug}}/.cursor/rules/worktree-env-local-probe.mdc
@@ -1,7 +1,7 @@
 ---
 description: >-
-  Cursor worktree bootstrap failed or env.local/op run debugging — read
-  file-based probe logs before inferring from missing direnv stderr
+  Worktree bootstrap failed, script/ ops blocked, or op/env.local confusion —
+  read probe + git-sync logs and classify before blaming 1Password
 alwaysApply: false
 globs:
   - .envrc
@@ -13,11 +13,15 @@ globs:
 
 `ls`/`cat` redirected to stderr in `.envrc` do **not** appear in worktree-fix bootstrap logs. Use file probes instead.
 
-## Before diagnosing bootstrap
+## Before diagnosing bootstrap or running `script/` ops
 
-1. Read the pointer: `.env-local-probe-path` (one line: absolute log path).
-2. Read the log tail: `~/.cache/env-local-probe/<worktree-basename>.log` (e.g. `kaa0.log`).
-3. If missing or stale, run from repo root: `./bin/probe_env_local` (no direnv required).
+Read **all three** (Grep/Read only while bootstrap is broken):
+
+1. Worktree-fix log — `~/.cache/cursor-apiology-bootstrap/worktree-fix/` (grep worktree path).
+2. Git-sync log — `~/.cursor/hooks/logs/git-sync-hooks.log` (same path; compare timestamps to worktree-fix).
+3. Probe log — `.env-local-probe-path` or `~/.cache/env-local-probe/<worktree-basename>.log`.
+
+If probe log missing for this worktree, run `./bin/probe_env_local` from repo root (no direnv required) or check git-sync vs worktree-fix timestamps — see stale-HEAD row in `apiology-direnv-bootstrap.mdc`.
 
 ## Interpret `which_branch`
 
@@ -28,4 +32,15 @@ globs:
 
 Also check: `-L`/`-r`, `cat exit=` (124 = FIFO with no writer / Environment not mounted), `op_run_fallback` section.
 
+Compare probe block timestamp to `~/.cursor/hooks/logs/git-sync-hooks.log` and worktree-fix log for the same root.
+
 Every `.envrc` eval appends a block (source=`envrc`). Bootstrap retries produce multiple timestamped blocks — compare hook time to latest block.
+
+## Contradiction patterns (classify, then act)
+
+| Pattern | Meaning |
+|---------|---------|
+| Hook log: `worktree-envlocal verified env.local` + fix log: 1Password/`op run` error + **no** probe run at bootstrap time (run `./bin/probe_env_local` to confirm `-L=yes`) | Stale checkout: `./fix.sh` ran before `git sync` merged `origin/main`. Retry bootstrap after sync; do not assume `.envrc` on disk differs from `git show HEAD:.envrc`. |
+| Probe `-L=yes` + fix log `op run` at same timestamp | Same stale-HEAD race or pre-`-L` `.envrc` at old commit. |
+| Probe `which_branch=env.local`, `cat exit=0` | `.envrc` took env.local path; if bootstrap still failed, debug `./fix.sh` output — not `op`. |
+| `git-sync … sync ok (merged …)` one second **after** `worktree-fix start` | Confirms race; hooks now re-sync inline — retry `./fix.sh`. |

--- a/{{cookiecutter.project_slug}}/bin/git-post-checkout-fix
+++ b/{{cookiecutter.project_slug}}/bin/git-post-checkout-fix
@@ -13,8 +13,20 @@ if [ "${branch_checkout}" != '1' ] || [ "${prev_head}" != "${NULL_REF}" ]; then
   exit 0
 fi
 
-# fix.sh calls bin/* helpers; .envrc (via direnv) adds bin/ to PATH.
-if [ -f .envrc ] && command -v direnv >/dev/null 2>&1; then
+# Git hooks often have a minimal PATH; include common direnv locations.
+export PATH="/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:${HOME}/.rbenv/bin:${HOME}/.local/bin:${PATH}"
+
+# fix.sh calls bin/* helpers; .envrc (via direnv) puts bin/ on PATH.
+# Never run bare ./fix.sh when .envrc exists — that skips PATH_add bin.
+if [ -f .envrc ]; then
+  if ! command -v direnv >/dev/null 2>&1; then
+    echo "git-post-checkout-fix: direnv not found; cannot bootstrap with .envrc" >&2
+    exit 1
+  fi
+  if ! direnv allow .; then
+    echo "git-post-checkout-fix: direnv allow failed" >&2
+    exit 1
+  fi
   exec direnv exec . ./fix.sh
 fi
 

--- a/{{cookiecutter.project_slug}}/fix.sh
+++ b/{{cookiecutter.project_slug}}/fix.sh
@@ -2,6 +2,10 @@
 
 set -o pipefail
 
+# Some tools need UTF-8; Cursor worktree hooks may run with LANG=C (US-ASCII).
+export LANG="${LANG:-en_US.UTF-8}"
+export LC_ALL="${LC_ALL:-en_US.UTF-8}"
+
 if [ -n "${FIX_SH_TIMING_LOG+x}" ]; then
     rm -f "${FIX_SH_TIMING_LOG}"
     if ! type gdate >/dev/null 2>&1; then sudo ln -sf /bin/date /bin/gdate; fi

--- a/{{cookiecutter.project_slug}}/fix.sh
+++ b/{{cookiecutter.project_slug}}/fix.sh
@@ -426,6 +426,12 @@ ensure_pip_and_wheel() {
 }
 
 ensure_python_requirements() {
+  # Stale CI pyenv caches can restore requirements_dev.txt.installed while the
+  # active virtualenv lacks packages (e.g. after python_versions / venv rename).
+  if ! type mypy >/dev/null 2>&1
+  then
+    rm -f requirements_dev.txt.installed
+  fi
   make pip_install
 }
 

--- a/{{cookiecutter.project_slug}}/fix.sh
+++ b/{{cookiecutter.project_slug}}/fix.sh
@@ -428,7 +428,8 @@ ensure_pip_and_wheel() {
 ensure_python_requirements() {
   # Stale CI pyenv caches can restore requirements_dev.txt.installed while the
   # active virtualenv lacks packages (e.g. after python_versions / venv rename).
-  if ! type mypy >/dev/null 2>&1
+  # Use import, not `type mypy` — pyenv shims exist for other versions.
+  if ! python -c 'import mypy' >/dev/null 2>&1
   then
     rm -f requirements_dev.txt.installed
   fi


### PR DESCRIPTION
## Summary
- Sync from cookiecutter-cookiecutter: worktree env.local probe triage docs, require direnv in `git-post-checkout-fix`, UTF-8 `LANG`/`LC_ALL` defaults in `fix.sh` (root + nested).
- Refresh `Gemfile.lock` (concurrent-ruby 1.3.8, Bundler 4.0.16) from the template bake.
- Clear git pre-push / Bundler hook env in bake tests so post_gen `git` ops do not reuse the parent worktree.
- Fix CI typecheck: new pyenv cache prefix (no loose `pyenv-` fallback) and reinstall Python deps when `import mypy` fails in the active virtualenv.

## Test plan
- [ ] CI green (build, quality)
- [ ] Spot-check `bin/git-post-checkout-fix` and `fix.sh` LANG defaults
- [ ] Confirm no unexpected deletions vs `origin/main`