### PR TITLE
Fix post_gen_project.py: CONTRIBUTING.md renamed to .rst

### DIFF
--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -27,7 +27,7 @@ if __name__ == '__main__':
 
     if 'Not open source' == '{{ cookiecutter.open_source_license }}':
         remove_file('LICENSE')
-        remove_file('CONTRIBUTING.md')
+        remove_file('CONTRIBUTING.rst')
 
     if os.environ.get('IN_COOKIECUTTER_PROJECT_UPGRADER', '0') == '1':
         os.environ['SKIP_GIT_CREATION'] = '1'

--- a/tests/test_bake_project.py
+++ b/tests/test_bake_project.py
@@ -182,4 +182,15 @@ def test_bake_and_run_build(cookies):
         license_file_path = result.project_path / 'LICENSE'
         now = datetime.datetime.now()
         assert str(now.year) in license_file_path.open().read()
+
+
+def test_bake_not_open_source(cookies):
+    """post_gen_project.py removes LICENSE and CONTRIBUTING.rst for closed-source projects."""
+    with bake_in_temp_dir(cookies,
+                          extra_context={
+                              'open_source_license': 'Not open source',
+                          }) as result:
+        found_toplevel_files = [f.name for f in result.project_path.iterdir()]
+        assert 'LICENSE' not in found_toplevel_files
+        assert 'CONTRIBUTING.rst' not in found_toplevel_files
         print('test_bake_and_run_build path', str(result.project_path))


### PR DESCRIPTION
## Summary
- hooks/post_gen_project.py removes CONTRIBUTING.md for closed-source bakes, but this tier's actual contributing doc has been CONTRIBUTING.rst since 2022 (commit b331383, added fresh — not a rename from .md; CONTRIBUTING.md has never existed in this repo's history on any branch). Every "Not open source" bake fails with FileNotFoundError.
- Correction from an earlier version of this description: I initially claimed a prior sync "renamed CONTRIBUTING.md to .rst" — that's wrong. git log --all --full-history shows CONTRIBUTING.md was never a file here. git blame shows the bad remove_file('CONTRIBUTING.md') line was introduced by the 2026-07-10 sync commit; the current parent template (cookiecutter-cookiecutter) has no such removal block at all, so it wasn't inherited from the parent's current tip either. Root provenance beyond that is unclear, but the fix itself is correct regardless: .rst is what's actually on disk.
- This blocked update_from_cookiecutter for all non-open-source repos on this template (surfaced while syncing apiology/apiology-tf in the update-from-upstream-cascade).
- Added test_bake_not_open_source, since this bake path had zero prior coverage — confirmed it fails without the fix and passes with it.

## Test plan
- [x] pytest tests/test_bake_project.py -v passes (2/2)
- [x] Confirmed the new test fails against the pre-fix hook (reverted locally, reran, saw FileNotFoundError)

## Provenance check (requested)
Checked whether .md was the convention upstream and terraform's .rst was the outlier that should be renamed instead. It isn't:
- Parent (cookiecutter-cookiecutter) full history: CONTRIBUTING.md has zero hits ever, on any branch, same as terraform. CONTRIBUTING.rst was added in the very first commit, "Import files from cookiecutter-pypackage" (2021-02-08) - this whole tree was bootstrapped from the cookiecutter-pypackage lineage, which conventionally ships RST docs.
- Every sibling template checked (cookiecutter-ruby, cookiecutter-chrome-extension, cookiecutter-multicli, cookiecutter-pypackage, cookiecutter-gem, cookiecutter-rails, cookiecutter-docker-image) uses CONTRIBUTING.rst, no exceptions.
- Conclusion: .rst is the tree-wide convention back to the root. CONTRIBUTING.md was never real anywhere in this lineage; the hook's reference to it was simply wrong. This fix's direction (point hook at .rst) is correct, not a workaround for a naming drift that should instead be fixed by renaming the file.
